### PR TITLE
Dynamically reload the JSON mapping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='keystone-json-assignment',
-    version='0.0.3',
+    version='0.0.4',
     description='JSON Backend for the Keystone Assignment Driver',
     url='https://github.com/SUSE-Cloud/keystone-json-assignment',
     author='Colleen Murphy',


### PR DESCRIPTION
This commit checks the mtime of the user-project-map.json file and
reloads it into the userprojectmap object if it has been modified since
the last reload. This means that changing the role assignments of users
no longer requires a full keystone restart.